### PR TITLE
Fix GameInfo gameNumber sanitization

### DIFF
--- a/src/lg/lg_game.js
+++ b/src/lg/lg_game.js
@@ -33,7 +33,7 @@ class GameInfo {
         this._history = [];
         this.gameNumber = new Date().toUTCString().split(' ')[4];
         if (this.gameNumber) {
-            this.gameNumber.replace(/:+/g, "42");
+            this.gameNumber = this.gameNumber.replace(/:+/g, '42');
         }
     }
 


### PR DESCRIPTION
## Summary
- fix a bug where `gameNumber` replacement didn't persist in GameInfo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff86a20e883228c55c39d2a180d75