### PR TITLE
Fix undici vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mocha": "^10.7.0",
         "promised-sqlite3": "^2.1.0",
         "sqlite3": "^5.1.7",
+        "undici": "^6.21.2",
         "winston": "^3.13.1",
         "winston-daily-rotate-file": "^5.0.0",
         "ytdl-core": "^4.11.5"
@@ -626,7 +627,7 @@
         "discord-api-types": "^0.38.1",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -2442,7 +2443,7 @@
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -6805,9 +6806,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "sqlite3": "^5.1.7",
     "winston": "^3.13.1",
     "winston-daily-rotate-file": "^5.0.0",
-    "ytdl-core": "^4.11.5"
+    "ytdl-core": "^4.11.5",
+    "undici": "^6.21.2"
   },
   "scripts": {
     "start": "node src/discordlgbot.js",
@@ -30,5 +31,8 @@
     "jest": "^29.7.0",
     "nyc": "^17.1.0",
     "sinon": "^20.0.0"
+  },
+  "overrides": {
+    "undici": "^6.21.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `undici` as a direct dependency to override vulnerable subdependency
- pin `undici` 6.21.3 via overrides
- update lockfile

## Testing
- `npm test`
- `npm audit --production`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684001245f288322896364c975029915