### PR TITLE
Add support for custom role compositions

### DIFF
--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -6,6 +6,7 @@ const messageUtils = require("../utils/message");
 const LgLogger = require("../lg/lg_logger.js");
 const get_random_in_array = require("../functions/parsing_functions").get_random_in_array;
 const SondageInfiniteChoice = require("../functions/cmds/referendum").SondageInfiniteChoice;
+const {parseRoleComposition} = require("../utils/roleCompositionParser");
 
 class GameOptions {
     constructor() {
@@ -21,6 +22,8 @@ class GameOptions {
             seed: 42,
             fast: false,
         };
+
+        this.roleComposition = null;
 
         return this;
     }
@@ -90,18 +93,48 @@ let askOptions = async (message, args) => {
             const n = parseInt(v, 10);
             return isNaN(n) ? d : n;
         };
-        for (const a of args) {
+
+        for (let i = 0; i < args.length; i++) {
+            const a = args[i];
+
+            const extractValue = () => {
+                const eqIndex = a.indexOf('=');
+                if (eqIndex !== -1) {
+                    const value = a.slice(eqIndex + 1).trim();
+                    if (value) {
+                        return value;
+                    }
+                }
+
+                const next = args[i + 1];
+                if (next && !next.startsWith('--')) {
+                    i += 1;
+                    return next;
+                }
+
+                return undefined;
+            };
+
             if (a.startsWith('--bots')) {
-                const parts = a.split('=');
-                const v = parts[1] || args[args.indexOf(a) + 1];
+                const v = extractValue();
                 gameOptions.ai.bots = getNum(v, 0);
                 gameOptions.ai.enabled = gameOptions.ai.bots > 0;
             } else if (a.startsWith('--seed')) {
-                const parts = a.split('=');
-                const v = parts[1] || args[args.indexOf(a) + 1];
+                const v = extractValue();
                 gameOptions.ai.seed = getNum(v, 42);
             } else if (a === '--fast') {
                 gameOptions.ai.fast = true;
+            } else if (a.startsWith('--roles')) {
+                const value = extractValue();
+                if (!value) {
+                    throw new Error('Missing role composition specification for --roles');
+                }
+
+                try {
+                    gameOptions.roleComposition = parseRoleComposition(value);
+                } catch (err) {
+                    throw new Error(`Invalid role composition: ${err.message}`);
+                }
             }
         }
     }

--- a/src/lg/lg_game.js
+++ b/src/lg/lg_game.js
@@ -306,7 +306,7 @@ class GamePreparation extends IGame {
         this.stemmingPlayer = player;
         this.preparationChannel = channel;
         this.configuration = new GameConfiguration(this.gameInfo);
-        this.rolesHandler = new RolesHandler(client, guild, this.gameInfo);
+        this.rolesHandler = new RolesHandler(client, guild, this.gameInfo, this.gameOptions && this.gameOptions.roleComposition);
         this.channelsHandler = new ChannelsHandler(client, guild, this.gameInfo);
         //this.voiceHandler = new VoiceHandler(this.channelsHandler._channels.get(this.channelsHandler.voiceChannels.vocal_lg), gameOptions.musicMode);
         this.configuration.rolesHandler = this.rolesHandler;

--- a/src/lg/roles/compositions/roleCompositionStrategy.js
+++ b/src/lg/roles/compositions/roleCompositionStrategy.js
@@ -1,0 +1,136 @@
+const clone = require('../../../functions/clone');
+
+class RandomRoleComposition {
+    apply(handler) {
+        handler.role_conf = [
+            {
+                LoupGarou: 1,
+            },
+            {
+                Voyante: 1,
+                Chasseur: 1,
+                Cupidon: 1,
+                Sorciere: 1,
+            },
+            {
+                LoupGarou: 1,
+            },
+            {
+                PetiteFille: 1,
+                Voleur: 1,
+            },
+            {
+                Villageois: 1,
+                LoupGarou: 1,
+                Salvateur: 1,
+                IdiotDuVillage: 1,
+                BoucEmissaire: 1,
+                JoueurDeFlute: 1,
+            },
+            {
+                Villageois: 1,
+                EnfantSauvage: 1,
+                Chevalier: 1,
+                Ange: 1,
+                InfectPereDesLoups: 1,
+                Soeur: 2,
+                Renard: 1,
+                ServanteDevouee: 1,
+                Frere: 3,
+                MontreurOurs: 1,
+                Comedien: 1,
+                AbominableSectaire: 1,
+                ChienLoup: 1,
+                VillageoisVillageois: 1,
+                Corbeau: 1,
+            },
+            {
+                GrandMechantLoup: 1,
+                Ancien: 1,
+                JugeBegue: 1,
+            },
+            {
+                Villageois: Number.MAX_SAFE_INTEGER,
+                LoupGarou: 1,
+            },
+        ];
+
+        handler.thiercelieux = [
+            handler.role_conf[0],
+            handler.role_conf[1],
+            handler.role_conf[2],
+            handler.role_conf[3],
+            handler.role_conf[7],
+        ];
+
+        handler.nouvelleLune = [
+            handler.role_conf[0],
+            handler.role_conf[1],
+            handler.role_conf[4],
+            handler.role_conf[7],
+        ];
+
+        handler.allExtension = handler.thiercelieux;
+        handler.gameType = handler.thiercelieux;
+
+        handler.gameTypeCopy = clone(handler.gameType);
+
+        let gameTypeCopyObj = handler.gameTypeCopy[0];
+        for (let i = 1; i < handler.gameTypeCopy.length; i++) {
+            gameTypeCopyObj = Object.assign(gameTypeCopyObj, handler.gameTypeCopy[i]);
+            handler.gameTypeCopy[0] = gameTypeCopyObj;
+        }
+
+        try {
+            delete gameTypeCopyObj.Voleur;
+            delete gameTypeCopyObj.Cupidon;
+            delete gameTypeCopyObj.JoueurDeFlute;
+        } catch (e) {
+            console.error(e);
+        }
+
+        handler.gameTypeCopy = [gameTypeCopyObj];
+    }
+}
+
+class CustomRoleComposition {
+    constructor(composition) {
+        this.composition = Object.assign({}, composition || {});
+    }
+
+    apply(handler) {
+        const sanitized = {};
+        for (const [role, count] of Object.entries(this.composition)) {
+            const value = Number.parseInt(count, 10);
+            if (Number.isInteger(value) && value > 0) {
+                sanitized[role] = value;
+            }
+        }
+
+        if (Object.keys(sanitized).length === 0) {
+            throw new Error('Custom role composition must contain at least one role');
+        }
+
+        const block = clone(sanitized);
+        handler.role_conf = [clone(sanitized)];
+        handler.gameType = [block];
+        handler.gameTypeCopy = [clone(block)];
+        handler.thiercelieux = handler.gameType;
+        handler.nouvelleLune = handler.gameType;
+        handler.allExtension = handler.gameType;
+    }
+}
+
+function createRoleCompositionStrategy(composition) {
+    if (composition && Object.keys(composition).length > 0) {
+        return new CustomRoleComposition(composition);
+    }
+
+    return new RandomRoleComposition();
+}
+
+module.exports = {
+    RandomRoleComposition,
+    CustomRoleComposition,
+    createRoleCompositionStrategy,
+};

--- a/src/lg/roles/lg_role.js
+++ b/src/lg/roles/lg_role.js
@@ -6,7 +6,7 @@ const get_random_in_array = require("../../functions/parsing_functions").get_ran
 const shuffle_array = require("../../functions/parsing_functions").shuffle_array;
 const ReactionHandler = require("../../functions/reactionHandler").ReactionHandler;
 
-const clone = require('../../functions/clone');
+const {createRoleCompositionStrategy} = require('./compositions/roleCompositionStrategy');
 
 const {Colors} = require('discord.js');
 const {sendEmbed} = require("../../utils/message");
@@ -25,7 +25,7 @@ class IGame {
 
 class RolesHandler extends IGame {
 
-    constructor(client, guild, gameInfo) {
+    constructor(client, guild, gameInfo, composition) {
         super(client);
 
         this.gameInfo = gameInfo;
@@ -79,91 +79,8 @@ class RolesHandler extends IGame {
             JugeBegue: LGGame.Create.jugeBegue,*/
         };
 
-        this.role_conf = [
-            {
-                LoupGarou: 1,
-            },
-            // Thiercelieux
-            {
-                Voyante: 1,
-                Chasseur: 1,
-                Cupidon: 1,
-                Sorciere: 1,
-            },
-            {
-                LoupGarou: 1,
-            },
-            {
-                PetiteFille: 1,
-                Voleur: 1,
-            },
-            // Nouvelle lune
-            {
-                Villageois: 1,
-                LoupGarou: 1,
-                Salvateur: 1,
-                IdiotDuVillage: 1,
-                BoucEmissaire: 1,
-                JoueurDeFlute: 1
-            },
-            {
-                Villageois: 1,
-                EnfantSauvage: 1,
-                Chevalier: 1,
-                Ange: 1,
-                InfectPereDesLoups: 1,
-                Soeur: 2, // todo: si une carte soeur est donnée, il faut donner la deuxième. Si impossible de donner la deuxième, donner un autre rôle.
-                Renard: 1,
-                ServanteDevouee: 1,
-                Frere: 3, // todo: si une carte soeur est donnée, il faut donner les autres. Si impossible de les donner, donner un autre rôle.
-                MontreurOurs: 1,
-                Comedien: 1,
-                AbominableSectaire: 1,
-                ChienLoup: 1,
-                VillageoisVillageois: 1,
-                Corbeau: 1
-            },
-            {
-                GrandMechantLoup: 1,
-                Ancien: 1,
-                JugeBegue: 1,
-            },
-            {
-                Villageois: Number.MAX_SAFE_INTEGER,
-                LoupGarou: 1
-            }
-        ];
-
-        this.thiercelieux = [
-            this.role_conf[0], this.role_conf[1], this.role_conf[2], this.role_conf[3], this.role_conf[7]
-        ];
-
-        this.nouvelleLune = [
-            this.role_conf[0], this.role_conf[1], this.role_conf[4], this.role_conf[7]
-        ];
-
-        this.allExtension = this.thiercelieux;
-
-        this.gameType = this.thiercelieux;
-
-        this.gameTypeCopy = clone(this.gameType);
-
-        let gameTypeCopyObj;
-
-        for (let i = 1; i < this.gameTypeCopy.length; i++) {
-            gameTypeCopyObj = Object.assign(this.gameTypeCopy[0], this.gameTypeCopy[i]);
-            this.gameTypeCopy[0] = gameTypeCopyObj;
-        }
-
-        try {
-            delete gameTypeCopyObj.Voleur;
-            delete gameTypeCopyObj.Cupidon;
-            delete gameTypeCopyObj.JoueurDeFlute;
-        } catch (e) {
-            console.error(e);
-        }
-
-        this.gameTypeCopy = [gameTypeCopyObj];
+        this.compositionStrategy = createRoleCompositionStrategy(composition);
+        this.compositionStrategy.apply(this);
 
         return this;
     }

--- a/src/utils/roleCompositionParser.js
+++ b/src/utils/roleCompositionParser.js
@@ -1,0 +1,42 @@
+function parseRoleComposition(spec) {
+    if (typeof spec !== 'string' || spec.trim() === '') {
+        throw new Error('Invalid role composition specification');
+    }
+
+    const tokens = spec
+        .split(/[;,]/)
+        .map(token => token.trim())
+        .filter(Boolean);
+
+    if (tokens.length === 0) {
+        throw new Error('Invalid role composition specification');
+    }
+
+    const composition = {};
+
+    for (const token of tokens) {
+        const [roleName, countString] = token.split(':').map(part => part && part.trim());
+
+        if (!roleName || !countString) {
+            throw new Error('Invalid role composition specification');
+        }
+
+        const count = Number.parseInt(countString, 10);
+
+        if (!Number.isInteger(count) || count <= 0) {
+            throw new Error('Invalid role composition specification');
+        }
+
+        composition[roleName] = (composition[roleName] || 0) + count;
+    }
+
+    if (Object.keys(composition).length === 0) {
+        throw new Error('Invalid role composition specification');
+    }
+
+    return composition;
+}
+
+module.exports = {
+    parseRoleComposition,
+};

--- a/test/lg/roles/roleCompositionStrategy.mocha.js
+++ b/test/lg/roles/roleCompositionStrategy.mocha.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+describe('Role composition strategies', () => {
+    const {
+        CustomRoleComposition,
+        RandomRoleComposition,
+        createRoleCompositionStrategy,
+    } = require('../../../src/lg/roles/compositions/roleCompositionStrategy');
+
+    it('createRoleCompositionStrategy returns custom strategy when composition provided', () => {
+        const strategy = createRoleCompositionStrategy({Villageois: 2});
+        assert.ok(strategy instanceof CustomRoleComposition);
+    });
+
+    it('createRoleCompositionStrategy returns random strategy when composition is null', () => {
+        const strategy = createRoleCompositionStrategy(null);
+        assert.ok(strategy instanceof RandomRoleComposition);
+    });
+
+    it('CustomRoleComposition applies configuration to handler', () => {
+        const handler = {};
+        const strategy = new CustomRoleComposition({Villageois: 3, LoupGarou: 1});
+        strategy.apply(handler);
+
+        assert.deepStrictEqual(handler.gameType, [{Villageois: 3, LoupGarou: 1}]);
+        assert.deepStrictEqual(handler.gameTypeCopy, [{Villageois: 3, LoupGarou: 1}]);
+        assert.strictEqual(handler.allExtension, handler.gameType);
+        assert.strictEqual(handler.thiercelieux, handler.gameType);
+        assert.strictEqual(handler.nouvelleLune, handler.gameType);
+    });
+
+    it('CustomRoleComposition clones data to avoid shared references', () => {
+        const handler = {};
+        const strategy = new CustomRoleComposition({Villageois: 2});
+        strategy.apply(handler);
+
+        assert.notStrictEqual(handler.gameType[0], handler.gameTypeCopy[0]);
+    });
+});

--- a/test/utils/roleCompositionParser.mocha.js
+++ b/test/utils/roleCompositionParser.mocha.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+
+describe('roleCompositionParser', () => {
+    const {parseRoleComposition} = require('../../src/utils/roleCompositionParser');
+
+    it('parses comma separated role specifications', () => {
+        const composition = parseRoleComposition('Villageois:5,LoupGarou:2,Voyante:1');
+        assert.deepStrictEqual(composition, {
+            Villageois: 5,
+            LoupGarou: 2,
+            Voyante: 1,
+        });
+    });
+
+    it('trims whitespace and merges duplicate role entries', () => {
+        const composition = parseRoleComposition('Villageois:3, LoupGarou:1, Villageois:2');
+        assert.deepStrictEqual(composition, {
+            Villageois: 5,
+            LoupGarou: 1,
+        });
+    });
+
+    it('supports semicolon separated specifications', () => {
+        const composition = parseRoleComposition('Villageois:4;LoupGarou:1');
+        assert.deepStrictEqual(composition, {
+            Villageois: 4,
+            LoupGarou: 1,
+        });
+    });
+
+    it('throws when specification is empty or invalid', () => {
+        assert.throws(() => parseRoleComposition(''), /role composition/i);
+        assert.throws(() => parseRoleComposition('Villageois'), /role composition/i);
+        assert.throws(() => parseRoleComposition('Villageois:-1'), /role composition/i);
+        assert.throws(() => parseRoleComposition('Villageois:abc'), /role composition/i);
+    });
+});


### PR DESCRIPTION
## Summary
- add a parser for `--roles` options so hosts can define explicit role counts when starting a game
- encapsulate role setup behind composition strategies to keep the existing random behaviour while enabling custom configurations
- cover the new parser and strategy classes with mocha tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5051d882483229db9bf5f033c1cbd